### PR TITLE
smenu: relax platform from linux to unix

### DIFF
--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
     license     = licenses.gpl2;
     maintainers = [ maintainers.matthiasbeyer ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
Enable building smenu on additional platforms, as smenu claims to support any Unix (and built fine on macos with `allowUnsupportedSystem = true`). Close #57410.

###### Things done

Not in a position to clone nixpkgs to a system for further testing at the moment; I'm just making this change via github's online interface.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
